### PR TITLE
ci: add PR build/test workflow; stabilize location property tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
       - dependency-type: all
     cooldown:
       default-days: 7
+    ignore:
+      # Hold TypeScript on its current major until typescript-eslint supports
+      # TypeScript 7 (its peer range currently caps at <6.1.0). Remove this
+      # once the linter toolchain ships TS 7 support, then upgrade deliberately.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: swift
     directory: "/safari"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref (e.g. force-pushes to a PR branch).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The Vite build reads from .env; the example file provides safe defaults.
+      - name: Set up environment file
+        run: cp .env.example .env
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Build (production)
+        run: npm run build:prod
+
+      # Validates the built extension bundle in dist/ (requires the build above).
+      - name: Lint extension bundle
+        run: npm run lint:ext
+
+      - name: Unit tests
+        run: npm test

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,21 @@ export default [
   // TypeScript recommended rules (type-aware)
   ...tseslint.configs.recommendedTypeChecked,
 
+  // Pin the TSConfig root for every file. `recommendedTypeChecked` applies the
+  // TS parser to all files; without an explicit tsconfigRootDir, newer
+  // typescript-eslint tries to infer it and errors when several candidates
+  // exist ("multiple candidate TSConfigRootDirs" — the repo root vs. cdk/).
+  // That surfaces on the CI checkout path (…/geospoof/geospoof) even though a
+  // local clone resolves to a single candidate. Harmless for the files that
+  // opt out of type-aware parsing below.
+  {
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+      },
+    },
+  },
+
   // TypeScript files configuration
   {
     files: ["src/**/*.ts", "tests/**/*.ts", "scripts/**/*.ts"],

--- a/tests/property/anti-fingerprint.property.test.ts
+++ b/tests/property/anti-fingerprint.property.test.ts
@@ -458,8 +458,10 @@ describe("Scoped resolvedOptions & Offset Properties", () => {
             return parseInt(part?.value ?? "0", 10);
           }
 
-          // getHours
-          const expectedHours = getExpected({ hour: "numeric", hour12: false }, "hour");
+          // getHours: en-US with hour12:false uses the h24 cycle, which renders
+          // local midnight as "24"; Date.prototype.getHours() is h23 (0-23), so
+          // normalize 24 -> 0 to compare like-for-like.
+          const expectedHours = getExpected({ hour: "numeric", hour12: false }, "hour") % 24;
           expect(contentScript.Date.prototype.getHours.call(testDate)).toBe(expectedHours);
 
           // getMinutes

--- a/tests/property/multi-tab-consistency.property.test.ts
+++ b/tests/property/multi-tab-consistency.property.test.ts
@@ -57,9 +57,13 @@ describe("Property 23: Multi-Tab Consistency", () => {
         fc.integer({ min: 1, max: 20 }),
         // Generate random location
         fc.record({
-          latitude: fc.double({ min: -90, max: 90 }),
-          longitude: fc.double({ min: -180, max: 180 }),
-          accuracy: fc.double({ min: 1, max: 100 }),
+          latitude: fc.double({ min: -90, max: 90, noNaN: true }),
+          // Domain is [-180, 180): +180 is the antimeridian, which the resolver
+          // canonicalizes to -180 (wrapLongitude). Exclude the upper bound so
+          // generated anchors are already in the delivered coordinate space.
+          // noNaN: NaN would be clamped to 0 by the resolver and break equality.
+          longitude: fc.double({ min: -180, max: 180, maxExcluded: true, noNaN: true }),
+          accuracy: fc.double({ min: 1, max: 100, noNaN: true }),
         }),
         // Generate random enabled state
         fc.boolean(),
@@ -146,9 +150,11 @@ describe("Property 23: Multi-Tab Consistency", () => {
         fc.integer({ min: 2, max: 10 }),
         fc.array(
           fc.record({
-            latitude: fc.double({ min: -90, max: 90 }),
-            longitude: fc.double({ min: -180, max: 180 }),
-            accuracy: fc.double({ min: 1, max: 100 }),
+            latitude: fc.double({ min: -90, max: 90, noNaN: true }),
+            // See note above: canonical [-180, 180) domain; noNaN so the resolver
+            // doesn't clamp NaN to 0 and break the cross-tab equality check.
+            longitude: fc.double({ min: -180, max: 180, maxExcluded: true, noNaN: true }),
+            accuracy: fc.double({ min: 1, max: 100, noNaN: true }),
           }),
           { minLength: 2, maxLength: 5 }
         ),

--- a/tests/property/per-tab-broadcast.property.test.ts
+++ b/tests/property/per-tab-broadcast.property.test.ts
@@ -114,7 +114,9 @@ const accuracySeedArb = fc.integer({ min: 0, max: 2 ** 31 });
 const locationArb = fc.option(
   fc.record({
     latitude: fc.double({ min: -90, max: 90, noNaN: true }),
-    longitude: fc.double({ min: -180, max: 180, noNaN: true }),
+    // [-180, 180): +180 canonicalizes to -180 in the delivered payload
+    // (wrapLongitude), so keep generated anchors in the canonical domain.
+    longitude: fc.double({ min: -180, max: 180, maxExcluded: true, noNaN: true }),
     accuracy: fc.integer({ min: 1, max: 1000 }),
   }),
   { nil: null }

--- a/tests/property/settings-dispatch.property.test.ts
+++ b/tests/property/settings-dispatch.property.test.ts
@@ -60,7 +60,15 @@ const arbAccuracySetting: fc.Arbitrary<AccuracySetting> = fc.oneof(
 /** fast-check arbitrary for a valid Location object, carrying accuracy resolution inputs. */
 const arbLocation = fc.record({
   latitude: fc.double({ min: -90, max: 90, noNaN: true, noDefaultInfinity: true }),
-  longitude: fc.double({ min: -180, max: 180, noNaN: true, noDefaultInfinity: true }),
+  // [-180, 180): +180 is the antimeridian, canonicalized to -180 downstream, so
+  // keep generated anchors in the canonical domain the round-trip compares against.
+  longitude: fc.double({
+    min: -180,
+    max: 180,
+    maxExcluded: true,
+    noNaN: true,
+    noDefaultInfinity: true,
+  }),
   accuracy: fc.double({ min: 0.1, max: 10000, noNaN: true, noDefaultInfinity: true }),
   accuracySetting: arbAccuracySetting,
   accuracySeed: fc.integer({ min: 0, max: 2 ** 31 }),

--- a/tests/property/settings.property.test.ts
+++ b/tests/property/settings.property.test.ts
@@ -20,7 +20,9 @@ const settingsArb: fc.Arbitrary<Settings> = fc.record({
   location: fc.option(
     fc.record({
       latitude: fc.double({ min: -90, max: 90, noNaN: true }),
-      longitude: fc.double({ min: -180, max: 180, noNaN: true }),
+      // [-180, 180): +180 canonicalizes to -180 in the delivered payload
+      // (wrapLongitude), so keep generated anchors in the canonical domain.
+      longitude: fc.double({ min: -180, max: 180, maxExcluded: true, noNaN: true }),
       accuracy: fc.integer({ min: 1, max: 1000 }),
     }),
     { nil: null }


### PR DESCRIPTION
## Summary Adds a CI workflow so PRs are actually validated (build + tests), plus two fixes surfaced while wiring it up. ### CI workflow (`.github/workflows/ci.yml`) Runs on `pull_request` and pushes to `main`: install → type-check → lint → format check → production build → extension lint → unit tests. Uses Node 20 with npm cache, matching the release workflows. Minimal `contents: read` permissions; concurrency cancels superseded runs. ### Dependabot: hold TypeScript majors Adds an `ignore` for TypeScript `semver-major` in the npm ecosystem. The grouped npm PR (#56) bumped TypeScript to 7.x, but `typescript-eslint` (latest 8.65.0) still peer-requires `typescript <6.1.0`, so `npm ci` fails to resolve. Remove this once typescript-eslint ships TS 7 support, then do the 6→7 jump as its own reviewed PR. ### Flaky property tests The suite had latent flakes (no CI ran it per-push). Tests that compare a broadcast payload's location to the raw generated input broke when fast-check probed boundary values: - **Longitude +180**: the resolver canonicalizes +180 → -180 (`wrapLongitude`, domain `[-180, 180)`). Generators now exclude the upper bound. - **NaN**: the multi-tab generators lacked `noNaN` (every other property file has it); NaN was clamped to 0, breaking equality. Added `noNaN: true`. Verified with 6 consecutive green full-suite runs locally. ## Testing - `npm run type-check`, `npm run lint`, `npm run format:check`, `npm run build:prod`, `npm run lint:ext` — all pass - `npm test` — 1671 tests pass, 6/6 repeated runs green