### PR TITLE
Real-time purchase alerts from App Store Server Notifications

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -17,7 +17,7 @@ This will place the ui components in the `components` directory.
 To use the components in your app, import them as follows:
 
 ```tsx
-import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/button"
 ```
 
 ## https
@@ -28,3 +28,67 @@ mkcert -install
 cd site
 mkcert -cert-file certs/dev-cert.pem -key-file certs/dev-key.pem localhost 127.0.0.1 ::1
 ```
+
+## Purchase alerts (App Store Server Notifications)
+
+`POST /api/apple-notifications` receives App Store Server Notifications V2 and
+forwards purchases, renewals, refunds and cancellations to a chat webhook. It is
+alerting only — Pro entitlement is still resolved on-device by StoreKit, so this
+route never grants or revokes access.
+
+### Vercel env vars
+
+| Variable                         | Required             | Purpose                                                                                                                                    |
+| -------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PURCHASE_ALERT_WEBHOOK_URL`     | yes                  | Discord or Slack incoming webhook (any other host gets a generic JSON body). Without it, alerts are dropped with a loud log.               |
+| `APPLE_NOTIFICATIONS_TOKEN`      | strongly recommended | Random secret that must appear as `?token=…` on the URL registered with Apple. Checked before any parsing or crypto; a miss answers 404.   |
+| `PURCHASE_ALERT_DISCORD_MENTION` | recommended          | Your Discord user id. Webhook posts ping nobody and servers default to "Only @mentions", so without this the alert won't reach your phone. |
+| `APPLE_BUNDLE_ID`                | no                   | Defaults to `com.moonloaf.geospoof`.                                                                                                       |
+| `APPLE_APP_APPLE_ID`             | no                   | Defaults to `6765719745`.                                                                                                                  |
+
+### Discord channel setup
+
+Put the webhook in a channel only you can read. If the GeoSpoof server is (or
+becomes) a community server, a sales feed in a member-visible channel publishes
+your revenue to everyone in it.
+
+1. Create the channel, then deny **View Channel** for `@everyone` in its
+   permissions and grant it to yourself only.
+2. Channel ▸ Edit Channel ▸ Integrations ▸ Webhooks ▸ New Webhook, and copy the URL
+   into `PURCHASE_ALERT_WEBHOOK_URL`. That URL is a credential — anyone holding it
+   can post to the channel, so keep it out of the repo and rotate it in Discord if
+   it leaks.
+3. Copy your own user id (Settings ▸ Advanced ▸ Developer Mode, then right-click
+   your name ▸ Copy User ID) into `PURCHASE_ALERT_DISCORD_MENTION`.
+4. On your phone, set that channel's notifications to **All Messages** as a
+   backstop.
+
+Alerts explicitly disable `@everyone`, `@here` and role pings, so the only thing a
+notification can ever mention is the configured user id.
+
+### App Store Connect setup
+
+In App Store Connect ▸ your app ▸ **App Information** ▸ App Store Server
+Notifications, set **both** URLs to version 2 of the same endpoint:
+
+```
+https://geospoof.com/api/apple-notifications?token=<APPLE_NOTIFICATIONS_TOKEN>
+```
+
+Registering the sandbox URL too is what makes TestFlight and App Review
+purchases visible; those alerts are tagged `[Sandbox]` so they can't be mistaken
+for revenue.
+
+### Verifying it works
+
+```
+APPLE_IAP_KEY=/path/to/AuthKey_XXXX.p8 \
+APPLE_IAP_KEY_ID=XXXX APPLE_IAP_ISSUER_ID=… \
+node scripts/apple-test-notification.mjs
+```
+
+That asks Apple to deliver a `TEST` notification and prints Apple's own delivery
+result, which distinguishes a TLS problem from a timeout from a non-2xx. It needs
+an **In-App Purchase** key (Users and Access ▸ Integrations ▸ In-App Purchase,
+Admin role) — the fastlane `ASC_API_KEY_P8` key is a different type and will not
+authenticate against the App Store Server API.

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "geospoof-site",
       "dependencies": {
+        "@apple/app-store-server-library": "3.1.0",
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/nunito": "5.2.7",
         "@tailwindcss/vite": "^4.2.1",
@@ -70,6 +71,79 @@
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@apple/app-store-server-library": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@apple/app-store-server-library/-/app-store-server-library-3.1.0.tgz",
+      "integrity": "sha512-d26SICRz8BwCV2qPR0BSXBMxmw0NEvJLwsdREcBmCrus8NmyHw2XgOOP0fiFjcctPn/JXtmSDuGVnaHe+dqO+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "^9.0.5",
+        "@types/jsrsasign": "^10.5.12",
+        "@types/node": "^25.4.0",
+        "@types/node-fetch": "^2.6.13",
+        "base64url": "^3.0.1",
+        "jsonwebtoken": "^9.0.2",
+        "jsrsasign": "^11.0.0",
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/@apple/app-store-server-library/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@apple/app-store-server-library/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apple/app-store-server-library/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/@apple/app-store-server-library/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/@apple/app-store-server-library/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@apple/app-store-server-library/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "4.1.2",
@@ -6632,6 +6706,22 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/jsrsasign": {
+      "version": "10.5.15",
+      "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.15.tgz",
+      "integrity": "sha512-3stUTaSRtN09PPzVWR6aySD9gNnuymz+WviNHoTb85dKu+BjaV4uBbWWGykBBJkfwPtcNZVfTn2lbX00U+yhpQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/leaflet": {
       "version": "1.9.21",
       "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
@@ -6663,7 +6753,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -6673,6 +6762,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/react": {
@@ -7666,6 +7765,12 @@
         "astring": "bin/astring"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/babel-dead-code-elimination": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/babel-dead-code-elimination/-/babel-dead-code-elimination-1.0.12.tgz",
@@ -7696,6 +7801,15 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -7828,6 +7942,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -8202,6 +8322,18 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -8813,6 +8945,15 @@
         "robust-predicates": "^3.0.2"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -8908,6 +9049,15 @@
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
       "license": "ISC"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/eciesjs": {
       "version": "0.4.18",
@@ -9071,6 +9221,21 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10133,6 +10298,43 @@
         "node": ">=12"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
@@ -10598,10 +10800,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -11364,6 +11581,68 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsrsasign": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.5.tgz",
+      "integrity": "sha512-i6mAjey0/4UQmlOaNS2vROl8EkWV8Ei436reJAby2OPQ3lF6uXSs1VYpnM8hndmmCMFIzNc04Uw2GF+0JVLFbg==",
+      "deprecated": "This package is no longer maintained.",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kapsule": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
@@ -11714,6 +11993,48 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {

--- a/site/package.json
+++ b/site/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@apple/app-store-server-library": "3.1.0",
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/nunito": "5.2.7",
     "@tailwindcss/vite": "^4.2.1",

--- a/site/scripts/apple-test-notification.mjs
+++ b/site/scripts/apple-test-notification.mjs
@@ -1,0 +1,130 @@
+/**
+ * Asks Apple to send a TEST notification to the URL registered in App Store
+ * Connect, then reports what Apple saw when it tried to deliver it.
+ *
+ * This is the only way to prove /api/apple-notifications works end to end
+ * without waiting for a real sale — and the `sendAttempts` it prints are
+ * Apple's own view of your server's response, which is far more useful than
+ * guessing from your logs (it distinguishes TLS problems, timeouts, redirects
+ * and a plain non-2xx).
+ *
+ * Usage:
+ *   node scripts/apple-test-notification.mjs                 # production URL
+ *   node scripts/apple-test-notification.mjs --sandbox       # sandbox URL
+ *
+ * Required env (all from App Store Connect):
+ *   APPLE_IAP_KEY_ID      Key ID of an In-App Purchase key
+ *   APPLE_IAP_ISSUER_ID   Issuer ID shown above the key list
+ *   APPLE_IAP_KEY         The .p8 contents, or a path to the .p8 file
+ *
+ * NOTE: the App Store Server API needs a key from Users and Access ▸
+ * Integrations ▸ **In-App Purchase** (creating one requires the Admin role).
+ * The existing `ASC_API_KEY_P8` / BXMZW4LMSP key used by fastlane is an App
+ * Store Connect API key with the App Manager role and will NOT authenticate
+ * here — they are different key types against different APIs.
+ */
+import { readFileSync } from "node:fs"
+import {
+  AppStoreServerAPIClient,
+  Environment,
+} from "@apple/app-store-server-library"
+
+const BUNDLE_ID = "com.moonloaf.geospoof"
+const POLL_ATTEMPTS = 10
+const POLL_INTERVAL_MS = 3_000
+
+const sandbox = process.argv.includes("--sandbox")
+const environment = sandbox ? Environment.SANDBOX : Environment.PRODUCTION
+
+function requireEnv(name) {
+  const value = process.env[name]?.trim()
+  if (!value) {
+    console.error(`Missing ${name}. See the header of this script for setup.`)
+    process.exit(1)
+  }
+  return value
+}
+
+/** Accept either the PEM text itself or a path to the .p8 file. */
+function resolveSigningKey(raw) {
+  if (raw.includes("BEGIN PRIVATE KEY")) return raw
+  try {
+    return readFileSync(raw, "utf8")
+  } catch {
+    console.error(
+      "APPLE_IAP_KEY is neither a PEM private key nor a readable path to a .p8 file."
+    )
+    process.exit(1)
+  }
+}
+
+const client = new AppStoreServerAPIClient(
+  resolveSigningKey(requireEnv("APPLE_IAP_KEY")),
+  requireEnv("APPLE_IAP_KEY_ID"),
+  requireEnv("APPLE_IAP_ISSUER_ID"),
+  BUNDLE_ID,
+  environment
+)
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+console.log(`Requesting a TEST notification (${environment})…`)
+
+let token
+try {
+  const response = await client.requestTestNotification()
+  token = response.testNotificationToken
+} catch (error) {
+  console.error("Apple refused the request:", error.message ?? error)
+  process.exit(1)
+}
+
+if (!token) {
+  console.error("Apple returned no testNotificationToken.")
+  process.exit(1)
+}
+console.log(`Token: ${token}`)
+
+// Apple records a delivery attempt asynchronously, so poll until it appears.
+for (let attempt = 1; attempt <= POLL_ATTEMPTS; attempt++) {
+  await sleep(POLL_INTERVAL_MS)
+  let status
+  try {
+    status = await client.getTestNotificationStatus(token)
+  } catch (error) {
+    console.error("Status check failed:", error.message ?? error)
+    process.exit(1)
+  }
+
+  const attempts = status.sendAttempts ?? []
+  if (attempts.length === 0) {
+    console.log(
+      `  no delivery attempt recorded yet (${attempt}/${POLL_ATTEMPTS})…`
+    )
+    continue
+  }
+
+  for (const item of attempts) {
+    const when = item.attemptDate
+      ? new Date(item.attemptDate).toISOString()
+      : "unknown time"
+    console.log(`  ${when}  ${item.sendAttemptResult}`)
+  }
+
+  const succeeded = attempts.some(
+    (item) => item.sendAttemptResult === "SUCCESS"
+  )
+  console.log(
+    succeeded
+      ? "\nApple delivered the TEST notification. Check your chat channel for an [INFO] line."
+      : "\nApple could not deliver it. The result above is the reason; a non-2xx from your" +
+          " endpoint shows as UNSUCCESSFUL_HTTP_RESPONSE_CODE (most often a wrong or missing" +
+          " ?token= on the registered URL, which answers 404 by design)."
+  )
+  process.exit(succeeded ? 0 : 1)
+}
+
+console.error(
+  "\nApple never recorded a delivery attempt. Is a URL registered for this environment?"
+)
+process.exit(1)

--- a/site/src/lib/purchase-alerts/apple-root-ca.ts
+++ b/site/src/lib/purchase-alerts/apple-root-ca.ts
@@ -1,0 +1,39 @@
+/**
+ * Apple Root CA - G3, the trust anchor for App Store Server Notifications.
+ *
+ * Apple signs each notification as a JWS whose `x5c` header carries the full
+ * certificate chain (leaf -> intermediate -> root). Verification means checking
+ * that chain terminates at a root we already trust, so the root has to be
+ * embedded here rather than read from the request.
+ *
+ * Why base64 in source instead of a `.cer` file: this runs inside a bundled
+ * Vercel/Nitro function. A `readFileSync` of a binary asset only works if the
+ * bundler happens to trace it; a string constant always survives.
+ *
+ * Provenance — downloaded from Apple's PKI page (https://www.apple.com/certificateauthority/)
+ * at https://www.apple.com/certificateauthority/AppleRootCA-G3.cer:
+ *   subject/issuer  CN=Apple Root CA - G3, OU=Apple Certification Authority, O=Apple Inc., C=US
+ *   validity        2014-04-30 -> 2039-04-30
+ *   SHA-256         63:34:3A:BF:B8:9A:6A:03:EB:B5:7E:9B:3F:5F:A7:BE:7C:4F:5C:75:6F:30:17:B3:A8:C4:88:C3:65:3E:91:79
+ *
+ * To re-verify this blob matches the published certificate:
+ *   curl -sO https://www.apple.com/certificateauthority/AppleRootCA-G3.cer
+ *   openssl x509 -inform der -in AppleRootCA-G3.cer -noout -fingerprint -sha256
+ */
+const APPLE_ROOT_CA_G3_BASE64 =
+  "MIICQzCCAcmgAwIBAgIILcX8iNLFS5UwCgYIKoZIzj0EAwMwZzEbMBkGA1UEAwwSQXBwbGUgUm9v" +
+  "dCBDQSAtIEczMSYwJAYDVQQLDB1BcHBsZSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTETMBEGA1UE" +
+  "CgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwHhcNMTQwNDMwMTgxOTA2WhcNMzkwNDMwMTgxOTA2" +
+  "WjBnMRswGQYDVQQDDBJBcHBsZSBSb290IENBIC0gRzMxJjAkBgNVBAsMHUFwcGxlIENlcnRpZmlj" +
+  "YXRpb24gQXV0aG9yaXR5MRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUzB2MBAGByqG" +
+  "SM49AgEGBSuBBAAiA2IABJjpLz1AcqTtkyJygRMc3RCV8cWjTnHcFBbZDuWmBSp3ZHtfTjjTuxxE" +
+  "tX/1H7YyYl3J6YRbTzBPEVoA/VhYDKX1DyxNB0cTddqXl5dvMVztK517IDvYuVTZXpmkOlEKMaNC" +
+  "MEAwHQYDVR0OBBYEFLuw3qFYM4iapIqZ3r6966/ayySrMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0P" +
+  "AQH/BAQDAgEGMAoGCCqGSM49BAMDA2gAMGUCMQCD6cHEFl4aXTQY2e3v9GwOAEZLuN+yRhHFD/3m" +
+  "eoyhpmvOwgPUnPWTxnS4at+qIxUCMG1mihDK1A3UT82NQz60imOlM27jbdoXt2QfyFMm+YhidDkL" +
+  "F1vLUagM6BgD56KyKA=="
+
+/** The DER bytes of Apple Root CA - G3, in the shape `SignedDataVerifier` wants. */
+export function appleRootCertificates(): Array<Buffer> {
+  return [Buffer.from(APPLE_ROOT_CA_G3_BASE64, "base64")]
+}

--- a/site/src/lib/purchase-alerts/config.ts
+++ b/site/src/lib/purchase-alerts/config.ts
@@ -1,0 +1,64 @@
+/**
+ * Server-only configuration for the purchase-alert webhook.
+ *
+ * Everything here is read from `process.env` at call time (not module scope) so
+ * a Vercel env-var change takes effect on the next invocation without a rebuild.
+ *
+ * The Apple identifiers default to GeoSpoof's real, public values — the bundle
+ * id ships in every build and the numeric app id is in the App Store URL — so
+ * only the two genuinely-private values need setting in Vercel.
+ */
+
+/** Bundle id every notification must be for. Rejects payloads for other apps. */
+const DEFAULT_BUNDLE_ID = "com.moonloaf.geospoof"
+
+/**
+ * The App Store's numeric app id (the `id…` in the App Store URL). Required by
+ * `SignedDataVerifier` for the Production environment; it cross-checks the
+ * `appAppleId` inside the payload.
+ */
+const DEFAULT_APP_APPLE_ID = 6765719745
+
+export interface PurchaseAlertConfig {
+  /** Incoming-webhook URL that receives the alert (Discord, Slack, or generic JSON). */
+  readonly webhookUrl: string | undefined
+  /**
+   * Optional Discord user id to mention, so the alert reliably pushes to your
+   * phone. A server's default notification setting is usually "Only @mentions",
+   * and a webhook post mentions nobody — so without this, alerts land silently
+   * in the channel and you find out about a sale when you next open Discord.
+   */
+  readonly mentionUserId: string | undefined
+  /**
+   * Shared secret required as `?token=…` on the notification URL. Apple lets you
+   * register any HTTPS URL, so a secret path/query is the cheapest way to keep
+   * unauthenticated traffic from reaching the (CPU-bound) signature check.
+   * Optional: when unset, the JWS signature is the only gate.
+   */
+  readonly urlToken: string | undefined
+  readonly bundleId: string
+  readonly appAppleId: number
+}
+
+function trimmed(value: string | undefined): string | undefined {
+  const v = value?.trim()
+  return v && v.length > 0 ? v : undefined
+}
+
+export function readConfig(
+  env: NodeJS.ProcessEnv = process.env
+): PurchaseAlertConfig {
+  const appAppleId = Number(
+    trimmed(env.APPLE_APP_APPLE_ID) ?? DEFAULT_APP_APPLE_ID
+  )
+
+  return {
+    webhookUrl: trimmed(env.PURCHASE_ALERT_WEBHOOK_URL),
+    mentionUserId: trimmed(env.PURCHASE_ALERT_DISCORD_MENTION),
+    urlToken: trimmed(env.APPLE_NOTIFICATIONS_TOKEN),
+    bundleId: trimmed(env.APPLE_BUNDLE_ID) ?? DEFAULT_BUNDLE_ID,
+    appAppleId: Number.isSafeInteger(appAppleId)
+      ? appAppleId
+      : DEFAULT_APP_APPLE_ID,
+  }
+}

--- a/site/src/lib/purchase-alerts/deliver.test.ts
+++ b/site/src/lib/purchase-alerts/deliver.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import { deliverAlert, webhookBody, webhookFlavor } from "./deliver"
+import type { PurchaseAlert } from "./format"
+
+const ALERT: PurchaseAlert = {
+  kind: "sale",
+  label: "SALE",
+  headline: "Pro Lifetime bought",
+  details: ["$24.99 (USA)"],
+  environment: "Production",
+}
+
+describe("webhookFlavor", () => {
+  it("recognizes Discord and Slack incoming webhooks", () => {
+    expect(webhookFlavor("https://discord.com/api/webhooks/123/abc")).toBe(
+      "discord"
+    )
+    expect(webhookFlavor("https://discordapp.com/api/webhooks/123/abc")).toBe(
+      "discord"
+    )
+    expect(webhookFlavor("https://hooks.slack.com/services/T0/B0/xxx")).toBe(
+      "slack"
+    )
+  })
+
+  it("treats anything else as a generic JSON endpoint", () => {
+    expect(webhookFlavor("https://alerts.example.com/hook")).toBe("generic")
+    expect(webhookFlavor("not a url")).toBe("generic")
+  })
+
+  // Guards against a lookalike host (e.g. discord.com.evil.test) being treated
+  // as Discord, which would send the alert body to the wrong shape and host.
+  it("matches on the host suffix, not a substring", () => {
+    expect(webhookFlavor("https://discord.com.evil.test/hook")).toBe("generic")
+  })
+})
+
+describe("webhookBody", () => {
+  it("uses `content` for Discord and `text` for Slack", () => {
+    expect(webhookBody(ALERT, "discord")).toEqual({
+      content: "[SALE] Pro Lifetime bought\n$24.99 (USA)",
+      allowed_mentions: { parse: [] },
+    })
+    expect(webhookBody(ALERT, "slack")).toEqual({
+      text: "[SALE] Pro Lifetime bought\n$24.99 (USA)",
+    })
+  })
+
+  // A webhook post pings nobody, and a Discord server defaults to "Only
+  // @mentions" — so without a mention the alert never reaches your phone.
+  it("prefixes a Discord mention when one is configured", () => {
+    expect(webhookBody(ALERT, "discord", "1234567890")).toEqual({
+      content: "<@1234567890> [SALE] Pro Lifetime bought\n$24.99 (USA)",
+      allowed_mentions: { parse: [], users: ["1234567890"] },
+    })
+  })
+
+  // Belt and braces for a channel that lives in a community server: no alert
+  // body should ever be able to ping @everyone.
+  it("never allows role or @everyone pings", () => {
+    const shouty: PurchaseAlert = { ...ALERT, headline: "@everyone bought Pro" }
+    const body = webhookBody(shouty, "discord", "1234567890") as {
+      allowed_mentions: { parse: Array<string>; users?: Array<string> }
+    }
+
+    expect(body.allowed_mentions.parse).toEqual([])
+    expect(body.allowed_mentions.users).toEqual(["1234567890"])
+  })
+
+  it("ignores a mention for non-Discord targets", () => {
+    expect(webhookBody(ALERT, "slack", "1234567890")).toEqual({
+      text: "[SALE] Pro Lifetime bought\n$24.99 (USA)",
+    })
+  })
+
+  it("includes the structured alert for a generic endpoint", () => {
+    expect(webhookBody(ALERT, "generic")).toEqual({
+      text: "[SALE] Pro Lifetime bought\n$24.99 (USA)",
+      alert: ALERT,
+    })
+  })
+
+  it("truncates text that would exceed Discord's content limit", () => {
+    const long: PurchaseAlert = { ...ALERT, headline: "x".repeat(2_500) }
+    const body = webhookBody(long, "discord") as { content: string }
+
+    expect(body.content.length).toBeLessThanOrEqual(1_900)
+    expect(body.content.endsWith("…")).toBe(true)
+  })
+})
+
+// deliverAlert's return value decides the HTTP status the route gives Apple:
+// false becomes a 500 so Apple retries, true becomes a 200. Getting this wrong
+// either loses the alert silently or has Apple redeliver for three days.
+describe("deliverAlert", () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it("posts the flavored body to the webhook and reports success", async () => {
+    const calls: Array<{ url: string; init: RequestInit | undefined }> = []
+    globalThis.fetch = ((url: string, init?: RequestInit) => {
+      calls.push({ url, init })
+      return Promise.resolve(new Response(null, { status: 204 }))
+    }) as unknown as typeof fetch
+
+    const delivered = await deliverAlert(
+      ALERT,
+      "https://discord.com/api/webhooks/1/abc"
+    )
+
+    expect(delivered).toBe(true)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].init?.method).toBe("POST")
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({
+      content: "[SALE] Pro Lifetime bought\n$24.99 (USA)",
+      allowed_mentions: { parse: [] },
+    })
+  })
+
+  it("reports failure when the webhook answers non-2xx", async () => {
+    globalThis.fetch = () =>
+      Promise.resolve(new Response("too many requests", { status: 429 }))
+
+    expect(
+      await deliverAlert(ALERT, "https://hooks.slack.com/services/T0/B0/x")
+    ).toBe(false)
+  })
+
+  it("reports failure instead of throwing when the request itself fails", async () => {
+    globalThis.fetch = () => Promise.reject(new Error("network unreachable"))
+
+    expect(await deliverAlert(ALERT, "https://alerts.example.com/hook")).toBe(
+      false
+    )
+  })
+})

--- a/site/src/lib/purchase-alerts/deliver.ts
+++ b/site/src/lib/purchase-alerts/deliver.ts
@@ -1,0 +1,107 @@
+/**
+ * Posts a purchase alert to an incoming-webhook URL.
+ *
+ * Discord and Slack both accept a single JSON POST with no auth beyond the
+ * secret in the URL, which is why they're the two shapes handled here — the
+ * target is picked from the URL's host so switching providers is an env-var
+ * change, not a code change. Anything else gets a generic body carrying both a
+ * `text` field and the structured alert.
+ *
+ * What leaves our infrastructure: product id, price, currency, storefront
+ * country, and Apple's opaque transaction id. No customer identity is in the
+ * notification to begin with (GeoSpoof sets no `appAccountToken`), and none is
+ * added here — worth keeping that way given the product's privacy stance.
+ */
+
+import { formatAlertText } from "./format"
+import type { PurchaseAlert } from "./format"
+
+/** Discord rejects `content` over 2000 characters; stay clear of the edge. */
+const MAX_TEXT_LENGTH = 1900
+
+/**
+ * Kept well inside the strictest Vercel function default (10s on a Hobby project
+ * without Fluid compute) so a hanging webhook can't turn into a platform timeout,
+ * which Apple would see as an ambiguous failure rather than our clean 500.
+ * Discord and Slack answer in well under a second in normal operation.
+ */
+const DELIVERY_TIMEOUT_MS = 5_000
+
+type WebhookFlavor = "discord" | "slack" | "generic"
+
+export function webhookFlavor(url: string): WebhookFlavor {
+  let host: string
+  try {
+    host = new URL(url).host.toLowerCase()
+  } catch {
+    return "generic"
+  }
+  if (host.endsWith("discord.com") || host.endsWith("discordapp.com"))
+    return "discord"
+  if (host.endsWith("slack.com")) return "slack"
+  return "generic"
+}
+
+function truncate(text: string): string {
+  return text.length <= MAX_TEXT_LENGTH
+    ? text
+    : `${text.slice(0, MAX_TEXT_LENGTH - 1)}…`
+}
+
+export function webhookBody(
+  alert: PurchaseAlert,
+  flavor: WebhookFlavor,
+  mentionUserId?: string
+): unknown {
+  const text = truncate(formatAlertText(alert))
+  switch (flavor) {
+    case "discord":
+      return {
+        content: mentionUserId ? `<@${mentionUserId}> ${text}` : text,
+        // Explicitly scope what a webhook post is allowed to ping. `parse: []`
+        // disables @everyone/@here/role pings outright, and only the configured
+        // user id can be mentioned — so no alert text can ever notify a whole
+        // server, which matters once the channel lives in a community server.
+        allowed_mentions: mentionUserId
+          ? { parse: [], users: [mentionUserId] }
+          : { parse: [] },
+      }
+    case "slack":
+      return { text }
+    case "generic":
+      return { text, alert }
+  }
+}
+
+/**
+ * Deliver the alert. Returns false rather than throwing so the caller can decide
+ * whether to make Apple retry; the reason is logged here.
+ */
+export async function deliverAlert(
+  alert: PurchaseAlert,
+  webhookUrl: string,
+  mentionUserId?: string
+): Promise<boolean> {
+  const flavor = webhookFlavor(webhookUrl)
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(webhookBody(alert, flavor, mentionUserId)),
+      signal: AbortSignal.timeout(DELIVERY_TIMEOUT_MS),
+    })
+    if (!response.ok) {
+      console.error(
+        `[purchase-alert] ${flavor} webhook rejected the alert: ${response.status} ${response.statusText}`
+      )
+      return false
+    }
+    return true
+  } catch (error) {
+    console.error(
+      `[purchase-alert] ${flavor} webhook delivery failed:`,
+      error instanceof Error ? error.message : error
+    )
+    return false
+  }
+}

--- a/site/src/lib/purchase-alerts/format.test.ts
+++ b/site/src/lib/purchase-alerts/format.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  Environment,
+  InAppOwnershipType,
+  NotificationTypeV2,
+  OfferType,
+  Subtype,
+  Type,
+} from "@apple/app-store-server-library"
+import {
+  describeNotification,
+  formatAlertText,
+  formatMoney,
+  productLabel,
+} from "./format"
+import type {
+  JWSTransactionDecodedPayload,
+  ResponseBodyV2DecodedPayload,
+} from "@apple/app-store-server-library"
+
+const LIFETIME = "com.moonloaf.geospoof.pro.lifetime"
+const ANNUAL = "com.moonloaf.geospoof.pro.annual"
+const TIP = "com.moonloaf.geospoof.tip.small"
+
+function notification(
+  overrides: Partial<ResponseBodyV2DecodedPayload> = {}
+): ResponseBodyV2DecodedPayload {
+  return {
+    notificationUUID: "8d7f0b6a-0000-4000-8000-000000000001",
+    data: {
+      environment: Environment.PRODUCTION,
+      bundleId: "com.moonloaf.geospoof",
+    },
+    ...overrides,
+  }
+}
+
+function transaction(
+  overrides: Partial<JWSTransactionDecodedPayload> = {}
+): JWSTransactionDecodedPayload {
+  return {
+    originalTransactionId: "2000000900000001",
+    transactionId: "2000000900000001",
+    productId: LIFETIME,
+    type: Type.NON_CONSUMABLE,
+    inAppOwnershipType: InAppOwnershipType.PURCHASED,
+    currency: "USD",
+    price: 24_990,
+    storefront: "USA",
+    quantity: 1,
+    ...overrides,
+  }
+}
+
+describe("productLabel", () => {
+  it("names the six shipping SKUs", () => {
+    expect(productLabel(LIFETIME)).toBe("Pro Lifetime")
+    expect(productLabel(ANNUAL)).toBe("Pro Annual")
+    expect(productLabel(TIP)).toBe("Coffee tip")
+  })
+
+  it("falls back to the raw id for an unknown product", () => {
+    expect(productLabel("com.moonloaf.geospoof.pro.quarterly")).toBe(
+      "com.moonloaf.geospoof.pro.quarterly"
+    )
+  })
+
+  it("stays readable when no product is present", () => {
+    expect(productLabel(undefined)).toBe("an in-app purchase")
+  })
+})
+
+describe("formatMoney", () => {
+  it("converts Apple's milliunits to a currency amount", () => {
+    expect(formatMoney(24_990, "USD")).toBe("$24.99")
+    expect(formatMoney(1_990, "USD")).toBe("$1.99")
+  })
+
+  it("handles non-USD storefronts", () => {
+    expect(formatMoney(14_990, "EUR")).toContain("14.99")
+  })
+
+  it("survives an unusable currency code", () => {
+    expect(formatMoney(24_990, "XYZZY")).toBe("24.99 XYZZY")
+  })
+
+  it("omits the amount entirely when Apple sent no price", () => {
+    expect(formatMoney(undefined, "USD")).toBeUndefined()
+  })
+})
+
+describe("describeNotification", () => {
+  it("reports a lifetime purchase as a sale with the amount and storefront", () => {
+    const alert = describeNotification(
+      notification({ notificationType: NotificationTypeV2.ONE_TIME_CHARGE }),
+      transaction()
+    )
+
+    expect(alert).not.toBeNull()
+    expect(alert?.kind).toBe("sale")
+    expect(alert?.headline).toBe("Pro Lifetime bought")
+    expect(alert?.details).toContain("$24.99 (USA)")
+    expect(alert?.details).toContain("txn 2000000900000001")
+  })
+
+  it("reports a tip purchase, including quantity above one", () => {
+    const alert = describeNotification(
+      notification({ notificationType: NotificationTypeV2.ONE_TIME_CHARGE }),
+      transaction({
+        productId: TIP,
+        type: Type.CONSUMABLE,
+        price: 1_990,
+        quantity: 2,
+      })
+    )
+
+    expect(alert?.kind).toBe("sale")
+    expect(alert?.headline).toBe("Coffee tip bought")
+    expect(alert?.details).toContain("$1.99 x2 (USA)")
+  })
+
+  // Both Pro plans ship a free introductory offer, so INITIAL_BUY is a trial
+  // start, not revenue. Mislabelling this would inflate every launch week.
+  it("labels an introductory-offer subscription as a trial, not a sale", () => {
+    const alert = describeNotification(
+      notification({
+        notificationType: NotificationTypeV2.SUBSCRIBED,
+        subtype: Subtype.INITIAL_BUY,
+      }),
+      transaction({
+        productId: ANNUAL,
+        type: Type.AUTO_RENEWABLE_SUBSCRIPTION,
+        offerType: OfferType.INTRODUCTORY_OFFER,
+        price: 0,
+        expiresDate: Date.UTC(2026, 8, 1),
+      })
+    )
+
+    expect(alert?.kind).toBe("trial")
+    expect(alert?.headline).toBe("New subscriber: Pro Annual (free trial)")
+    expect(alert?.details).toContain("Converts 2026-09-01")
+    // A "$0.00" line would be noise next to that headline.
+    expect(alert?.details.some((line) => line.includes("0.00"))).toBe(false)
+  })
+
+  it("reports a paid first subscription as a sale with the renewal date", () => {
+    const alert = describeNotification(
+      notification({
+        notificationType: NotificationTypeV2.SUBSCRIBED,
+        subtype: Subtype.INITIAL_BUY,
+      }),
+      transaction({
+        productId: ANNUAL,
+        type: Type.AUTO_RENEWABLE_SUBSCRIPTION,
+        price: 14_990,
+        expiresDate: Date.UTC(2027, 7, 24),
+      })
+    )
+
+    expect(alert?.kind).toBe("sale")
+    expect(alert?.headline).toBe("New subscriber: Pro Annual")
+    expect(alert?.details).toContain("$14.99 (USA)")
+    expect(alert?.details).toContain("Renews 2027-08-24")
+  })
+
+  it("distinguishes a resubscribe from a first-time subscriber", () => {
+    const alert = describeNotification(
+      notification({
+        notificationType: NotificationTypeV2.SUBSCRIBED,
+        subtype: Subtype.RESUBSCRIBE,
+      }),
+      transaction({ productId: ANNUAL, price: 14_990 })
+    )
+
+    expect(alert?.headline).toBe("Resubscribed to Pro Annual")
+  })
+
+  it("reports renewals, and says so when billing recovered", () => {
+    const renewal = describeNotification(
+      notification({ notificationType: NotificationTypeV2.DID_RENEW }),
+      transaction({ productId: ANNUAL, price: 14_990 })
+    )
+    expect(renewal?.kind).toBe("sale")
+    expect(renewal?.headline).toBe("Pro Annual renewed")
+
+    const recovered = describeNotification(
+      notification({
+        notificationType: NotificationTypeV2.DID_RENEW,
+        subtype: Subtype.BILLING_RECOVERY,
+      }),
+      transaction({ productId: ANNUAL, price: 14_990 })
+    )
+    expect(recovered?.headline).toBe("Pro Annual renewed (billing recovered)")
+  })
+
+  // Family Sharing produces the same notification type as a purchase but no
+  // charge, so it must not be counted as a sale.
+  it("separates Family Sharing access from a purchase", () => {
+    const alert = describeNotification(
+      notification({ notificationType: NotificationTypeV2.ONE_TIME_CHARGE }),
+      transaction({ inAppOwnershipType: InAppOwnershipType.FAMILY_SHARED })
+    )
+
+    expect(alert?.kind).toBe("info")
+    expect(alert?.headline).toBe("Pro Lifetime shared via Family Sharing")
+  })
+
+  it("reports refunds and cancellations", () => {
+    expect(
+      describeNotification(
+        notification({ notificationType: NotificationTypeV2.REFUND }),
+        transaction()
+      )?.kind
+    ).toBe("refund")
+
+    const cancelled = describeNotification(
+      notification({
+        notificationType: NotificationTypeV2.DID_CHANGE_RENEWAL_STATUS,
+        subtype: Subtype.AUTO_RENEW_DISABLED,
+      }),
+      transaction({ productId: ANNUAL, expiresDate: Date.UTC(2026, 11, 25) })
+    )
+    expect(cancelled?.kind).toBe("churn")
+    expect(cancelled?.headline).toBe("Auto-renew turned off for Pro Annual")
+    expect(cancelled?.details).toContain("Access until 2026-12-25")
+
+    expect(
+      describeNotification(
+        notification({
+          notificationType: NotificationTypeV2.EXPIRED,
+          subtype: Subtype.BILLING_RETRY,
+        }),
+        transaction({ productId: ANNUAL })
+      )?.headline
+    ).toBe("Pro Annual expired (billing failed)")
+  })
+
+  it("reports a requested test notification so the wiring is verifiable", () => {
+    const alert = describeNotification(
+      notification({ notificationType: NotificationTypeV2.TEST }),
+      undefined
+    )
+
+    expect(alert?.kind).toBe("info")
+    expect(alert?.headline).toContain("Test notification")
+  })
+
+  it("stays quiet for plumbing notifications", () => {
+    for (const notificationType of [
+      NotificationTypeV2.CONSUMPTION_REQUEST,
+      NotificationTypeV2.RENEWAL_EXTENSION,
+      NotificationTypeV2.PRICE_INCREASE,
+      NotificationTypeV2.METADATA_UPDATE,
+      NotificationTypeV2.EXTERNAL_PURCHASE_TOKEN,
+    ]) {
+      expect(
+        describeNotification(notification({ notificationType }), transaction())
+      ).toBeNull()
+    }
+  })
+
+  it("stays quiet for a notification type it has never seen", () => {
+    expect(
+      describeNotification(
+        notification({ notificationType: "SOMETHING_APPLE_ADDED_LATER" }),
+        transaction()
+      )
+    ).toBeNull()
+  })
+})
+
+describe("formatAlertText", () => {
+  it("puts the label first and the details on a second line", () => {
+    const alert = describeNotification(
+      notification({ notificationType: NotificationTypeV2.ONE_TIME_CHARGE }),
+      transaction()
+    )
+
+    expect(formatAlertText(alert!)).toBe(
+      "[SALE] Pro Lifetime bought\n$24.99 (USA) · txn 2000000900000001"
+    )
+  })
+
+  it("tags sandbox events so TestFlight and App Review can't look like revenue", () => {
+    const alert = describeNotification(
+      notification({
+        notificationType: NotificationTypeV2.ONE_TIME_CHARGE,
+        data: { environment: Environment.SANDBOX },
+      }),
+      transaction()
+    )
+
+    expect(formatAlertText(alert!)).toContain(
+      "[SALE] [Sandbox] Pro Lifetime bought"
+    )
+  })
+})

--- a/site/src/lib/purchase-alerts/format.ts
+++ b/site/src/lib/purchase-alerts/format.ts
@@ -1,0 +1,313 @@
+/**
+ * Turns a verified App Store notification into the one-line alert that lands in
+ * chat. Pure and side-effect free so it can be unit tested against fixtures
+ * without any Apple credentials or network.
+ *
+ * Two deliberate editorial choices:
+ *
+ *  1. A subscription "purchase" is usually not money yet. Both Pro plans ship a
+ *     free introductory offer, so `SUBSCRIBED / INITIAL_BUY` fires at trial
+ *     start with `price: 0`. Reporting that as a sale would overstate revenue,
+ *     so trials get their own label and the conversion date.
+ *  2. Family Sharing access produces the same `ONE_TIME_CHARGE` /`SUBSCRIBED`
+ *     types as a real purchase, with `inAppOwnershipType: FAMILY_SHARED` and no
+ *     new charge. It's labelled separately for the same reason.
+ */
+
+import {
+  InAppOwnershipType,
+  NotificationTypeV2,
+  OfferType,
+  Subtype,
+} from "@apple/app-store-server-library"
+import type {
+  JWSTransactionDecodedPayload,
+  ResponseBodyV2DecodedPayload,
+} from "@apple/app-store-server-library"
+
+export type AlertKind = "sale" | "trial" | "churn" | "refund" | "info"
+
+export interface PurchaseAlert {
+  readonly kind: AlertKind
+  /** Short scannable prefix, e.g. "SALE". */
+  readonly label: string
+  /** The headline, e.g. "Pro Lifetime bought". */
+  readonly headline: string
+  /** Supporting lines: money, storefront, plan dates, ids. */
+  readonly details: ReadonlyArray<string>
+  /** "Production" | "Sandbox" — sandbox alerts are tagged so they can't be mistaken for revenue. */
+  readonly environment: string | undefined
+}
+
+const LABELS: Record<AlertKind, string> = {
+  sale: "SALE",
+  trial: "TRIAL",
+  churn: "CHURN",
+  refund: "REFUND",
+  info: "INFO",
+}
+
+/**
+ * Friendly names for the six SKUs (see `ProStore.ProductID` and `TipStore`).
+ * Unknown ids fall through to the raw product id rather than being dropped, so a
+ * newly added SKU still produces a usable alert before this map is updated.
+ */
+const PRODUCT_NAMES: Record<string, string> = {
+  "com.moonloaf.geospoof.pro.monthly": "Pro Monthly",
+  "com.moonloaf.geospoof.pro.annual": "Pro Annual",
+  "com.moonloaf.geospoof.pro.lifetime": "Pro Lifetime",
+  "com.moonloaf.geospoof.tip.small": "Coffee tip",
+  "com.moonloaf.geospoof.tip.medium": "Lunch tip",
+  "com.moonloaf.geospoof.tip.large": "Dinner tip",
+}
+
+export function productLabel(productId: string | undefined): string {
+  if (!productId) return "an in-app purchase"
+  return PRODUCT_NAMES[productId] ?? productId
+}
+
+/**
+ * Apple reports `price` in milliunits of `currency` (24990 = 24.99). Returns
+ * undefined when either half is missing, so callers can omit the line entirely
+ * instead of printing a misleading "0".
+ */
+export function formatMoney(
+  priceMilliunits: number | undefined,
+  currency: string | undefined
+): string | undefined {
+  if (
+    typeof priceMilliunits !== "number" ||
+    !Number.isFinite(priceMilliunits)
+  ) {
+    return undefined
+  }
+  const amount = priceMilliunits / 1000
+  if (!currency) return amount.toFixed(2)
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+      currencyDisplay: "narrowSymbol",
+    }).format(amount)
+  } catch {
+    // Unknown/invalid ISO 4217 code — still report the number.
+    return `${amount.toFixed(2)} ${currency}`
+  }
+}
+
+function formatDate(ms: number | undefined): string | undefined {
+  if (typeof ms !== "number" || !Number.isFinite(ms)) return undefined
+  const date = new Date(ms)
+  return Number.isNaN(date.getTime())
+    ? undefined
+    : date.toISOString().slice(0, 10)
+}
+
+function isFamilyShared(
+  transaction: JWSTransactionDecodedPayload | undefined
+): boolean {
+  return transaction?.inAppOwnershipType === InAppOwnershipType.FAMILY_SHARED
+}
+
+/** A free introductory offer, i.e. a trial rather than a charge. */
+function isFreeTrial(
+  transaction: JWSTransactionDecodedPayload | undefined
+): boolean {
+  if (!transaction) return false
+  if (transaction.offerType === OfferType.INTRODUCTORY_OFFER) return true
+  return transaction.price === 0
+}
+
+function moneyDetail(
+  transaction: JWSTransactionDecodedPayload | undefined
+): string | undefined {
+  const money = formatMoney(transaction?.price, transaction?.currency)
+  if (!money) return undefined
+  const storefront = transaction?.storefront
+  const quantity =
+    typeof transaction?.quantity === "number" && transaction.quantity > 1
+      ? ` x${transaction.quantity}`
+      : ""
+  return storefront
+    ? `${money}${quantity} (${storefront})`
+    : `${money}${quantity}`
+}
+
+interface Verdict {
+  kind: AlertKind
+  headline: string
+  /** Extra lines specific to this verdict, appended after the money line. */
+  extra?: ReadonlyArray<string | undefined>
+}
+
+/**
+ * Map notification type + subtype to a verdict, or null for the types we
+ * deliberately stay quiet about (consumption requests, price-increase notices,
+ * renewal-date extensions, Advanced Commerce and external-purchase plumbing).
+ * Staying quiet is the default for anything unrecognised: this feed is only
+ * useful if every message in it is worth reading.
+ */
+function verdictFor(
+  payload: ResponseBodyV2DecodedPayload,
+  transaction: JWSTransactionDecodedPayload | undefined
+): Verdict | null {
+  const product = productLabel(transaction?.productId)
+  const renews = formatDate(transaction?.expiresDate)
+
+  switch (payload.notificationType) {
+    case NotificationTypeV2.SUBSCRIBED: {
+      if (isFamilyShared(transaction)) {
+        return {
+          kind: "info",
+          headline: `${product} shared via Family Sharing`,
+        }
+      }
+      const first =
+        payload.subtype === Subtype.RESUBSCRIBE
+          ? "Resubscribed to"
+          : "New subscriber:"
+      if (isFreeTrial(transaction)) {
+        return {
+          kind: "trial",
+          headline: `${first} ${product} (free trial)`,
+          extra: [renews ? `Converts ${renews}` : undefined],
+        }
+      }
+      return {
+        kind: "sale",
+        headline: `${first} ${product}`,
+        extra: [renews ? `Renews ${renews}` : undefined],
+      }
+    }
+
+    case NotificationTypeV2.DID_RENEW:
+      return {
+        kind: "sale",
+        headline:
+          payload.subtype === Subtype.BILLING_RECOVERY
+            ? `${product} renewed (billing recovered)`
+            : `${product} renewed`,
+        extra: [renews ? `Next renewal ${renews}` : undefined],
+      }
+
+    case NotificationTypeV2.ONE_TIME_CHARGE:
+      if (isFamilyShared(transaction)) {
+        return {
+          kind: "info",
+          headline: `${product} shared via Family Sharing`,
+        }
+      }
+      return { kind: "sale", headline: `${product} bought` }
+
+    case NotificationTypeV2.OFFER_REDEEMED:
+      return { kind: "sale", headline: `Offer redeemed on ${product}` }
+
+    case NotificationTypeV2.REFUND:
+      return { kind: "refund", headline: `${product} refunded` }
+
+    case NotificationTypeV2.REFUND_REVERSED:
+      return { kind: "info", headline: `Refund reversed on ${product}` }
+
+    case NotificationTypeV2.REVOKE:
+      return {
+        kind: "churn",
+        headline: `${product} access revoked (Family Sharing ended)`,
+      }
+
+    case NotificationTypeV2.DID_CHANGE_RENEWAL_STATUS:
+      if (payload.subtype === Subtype.AUTO_RENEW_DISABLED) {
+        return {
+          kind: "churn",
+          headline: `Auto-renew turned off for ${product}`,
+          extra: [renews ? `Access until ${renews}` : undefined],
+        }
+      }
+      return {
+        kind: "info",
+        headline: `Auto-renew turned back on for ${product}`,
+      }
+
+    case NotificationTypeV2.DID_CHANGE_RENEWAL_PREF: {
+      if (payload.subtype === Subtype.UPGRADE) {
+        return { kind: "sale", headline: `Upgraded to ${product}` }
+      }
+      if (payload.subtype === Subtype.DOWNGRADE) {
+        return { kind: "info", headline: `Downgrade scheduled to ${product}` }
+      }
+      return { kind: "info", headline: `Plan change cancelled on ${product}` }
+    }
+
+    case NotificationTypeV2.EXPIRED:
+      return {
+        kind: "churn",
+        headline:
+          payload.subtype === Subtype.BILLING_RETRY
+            ? `${product} expired (billing failed)`
+            : `${product} expired`,
+      }
+
+    case NotificationTypeV2.DID_FAIL_TO_RENEW:
+      return {
+        kind: "churn",
+        headline: `${product} failed to renew (billing retry${
+          payload.subtype === Subtype.GRACE_PERIOD ? ", in grace period" : ""
+        })`,
+      }
+
+    case NotificationTypeV2.GRACE_PERIOD_EXPIRED:
+      return { kind: "churn", headline: `${product} grace period ended` }
+
+    case NotificationTypeV2.TEST:
+      return {
+        kind: "info",
+        headline: "Test notification received — the webhook works",
+      }
+
+    default:
+      return null
+  }
+}
+
+/**
+ * Build the alert for a verified notification, or null when this event type is
+ * intentionally not reported.
+ */
+export function describeNotification(
+  payload: ResponseBodyV2DecodedPayload,
+  transaction: JWSTransactionDecodedPayload | undefined
+): PurchaseAlert | null {
+  const verdict = verdictFor(payload, transaction)
+  if (!verdict) return null
+
+  const details: Array<string> = []
+  const money = moneyDetail(transaction)
+  // A trial's "$0.00" line adds nothing the headline doesn't already say.
+  if (money && verdict.kind !== "trial") details.push(money)
+  for (const line of verdict.extra ?? []) {
+    if (line) details.push(line)
+  }
+  // Opaque, Apple-issued id. No customer identity is available here (GeoSpoof
+  // sets no appAccountToken), and none should be added — it's the one field that
+  // makes an alert traceable back to a specific transaction in App Store Connect.
+  if (transaction?.originalTransactionId) {
+    details.push(`txn ${transaction.originalTransactionId}`)
+  }
+
+  return {
+    kind: verdict.kind,
+    label: LABELS[verdict.kind],
+    headline: verdict.headline,
+    details,
+    environment: payload.data?.environment,
+  }
+}
+
+/** Render an alert as the plain-text line posted to chat. */
+export function formatAlertText(alert: PurchaseAlert): string {
+  const sandboxTag =
+    alert.environment && alert.environment !== "Production" ? " [Sandbox]" : ""
+  const head = `[${alert.label}]${sandboxTag} ${alert.headline}`
+  return alert.details.length > 0
+    ? `${head}\n${alert.details.join(" · ")}`
+    : head
+}

--- a/site/src/lib/purchase-alerts/handle.ts
+++ b/site/src/lib/purchase-alerts/handle.ts
@@ -1,0 +1,121 @@
+/**
+ * The purchase-alert pipeline: verify -> decide -> deliver.
+ *
+ * Deliberately split out of the route module so it can be loaded lazily. Apple's
+ * library and its `node-fetch` dependency are ~200 KB of JS, and the route file
+ * gets bundled into the shared SSR router chunk — a static import there means
+ * every server-rendered request (`/test`, `/verify`, the `/verify` server
+ * function) pays to parse and initialise a certificate verifier it will never
+ * use. Behind a dynamic import, that cost is only paid when Apple actually
+ * POSTs.
+ */
+
+import { readConfig } from "./config"
+import { deliverAlert } from "./deliver"
+import { describeNotification } from "./format"
+import { describeVerificationFailure, verifyNotification } from "./verify"
+
+/**
+ * Apple can deliver the same notification more than once (its own retries, plus
+ * at-least-once delivery), and `notificationUUID` is the documented dedup key.
+ *
+ * Best-effort by design: this lives in one warm serverless instance, so a
+ * duplicate that lands on a cold instance still gets through. That's an accepted
+ * trade — the alternative is a KV store for a problem whose worst case is seeing
+ * the same sale twice. A UUID is only recorded once delivery has SUCCEEDED, so a
+ * retry after a failed webhook post is still able to alert.
+ */
+const MAX_REMEMBERED = 500
+const deliveredNotificationIds = new Set<string>()
+
+function rememberDelivered(notificationUUID: string | undefined): void {
+  if (!notificationUUID) return
+  deliveredNotificationIds.add(notificationUUID)
+  if (deliveredNotificationIds.size > MAX_REMEMBERED) {
+    // Sets iterate in insertion order, so this evicts the oldest.
+    const oldest = deliveredNotificationIds.values().next()
+    if (!oldest.done) deliveredNotificationIds.delete(oldest.value)
+  }
+}
+
+async function readSignedPayload(
+  request: Request
+): Promise<string | undefined> {
+  try {
+    const body: unknown = await request.json()
+    if (typeof body !== "object" || body === null) return undefined
+    const signedPayload = (body as { signedPayload?: unknown }).signedPayload
+    return typeof signedPayload === "string" && signedPayload.length > 0
+      ? signedPayload
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Handle one notification. See the route module for the status-code contract —
+ * the codes are load-bearing, because any non-2xx makes Apple redeliver.
+ */
+export async function handleNotification(request: Request): Promise<Response> {
+  const config = readConfig()
+
+  const signedPayload = await readSignedPayload(request)
+  if (!signedPayload) {
+    return new Response("Expected a JSON body with a signedPayload string", {
+      status: 400,
+    })
+  }
+
+  let verified
+  try {
+    verified = await verifyNotification(signedPayload, config)
+  } catch (error) {
+    console.error(
+      "[purchase-alert] notification failed verification:",
+      describeVerificationFailure(error)
+    )
+    return new Response("Signature verification failed", { status: 401 })
+  }
+
+  const { payload, transaction } = verified
+  const summary = `${payload.notificationType ?? "unknown"}${
+    payload.subtype ? `/${payload.subtype}` : ""
+  } (${payload.data?.environment ?? "unknown env"})`
+
+  if (
+    payload.notificationUUID &&
+    deliveredNotificationIds.has(payload.notificationUUID)
+  ) {
+    console.info(`[purchase-alert] duplicate ${summary}, already delivered`)
+    return new Response(null, { status: 200 })
+  }
+
+  const alert = describeNotification(payload, transaction)
+  if (!alert) {
+    console.info(`[purchase-alert] ${summary} is not reported`)
+    return new Response(null, { status: 200 })
+  }
+
+  if (!config.webhookUrl) {
+    // Misconfiguration, not a transient failure: retrying for three days won't
+    // conjure an env var, so ack and make the reason loud instead.
+    console.error(
+      `[purchase-alert] PURCHASE_ALERT_WEBHOOK_URL is not set — dropping ${summary}`
+    )
+    return new Response(null, { status: 200 })
+  }
+
+  const delivered = await deliverAlert(
+    alert,
+    config.webhookUrl,
+    config.mentionUserId
+  )
+  if (!delivered) {
+    return new Response("Alert delivery failed", { status: 500 })
+  }
+
+  rememberDelivered(payload.notificationUUID)
+  console.info(`[purchase-alert] delivered ${summary}`)
+  return new Response(null, { status: 200 })
+}

--- a/site/src/lib/purchase-alerts/verify.ts
+++ b/site/src/lib/purchase-alerts/verify.ts
@@ -1,0 +1,171 @@
+/**
+ * Signature verification for App Store Server Notifications V2.
+ *
+ * Apple POSTs `{ "signedPayload": "<JWS>" }` with no bearer token, no HMAC, and
+ * no fixed source IP — the JWS signature IS the authentication. So this module
+ * is the security boundary for the endpoint: anything it rejects never reaches
+ * the alert path.
+ *
+ * Apple's own library does the heavy lifting (x5c chain validation against the
+ * embedded Apple root, effective-date checks, bundle-id and appAppleId
+ * cross-checks). What this file adds:
+ *
+ *   - One verifier per environment. Apple signs Sandbox notifications with a
+ *     Sandbox-scoped payload and the verifier rejects a mismatched environment,
+ *     so a single verifier cannot serve both. Registering the same URL for both
+ *     environments in App Store Connect is convenient (and is what makes
+ *     TestFlight / App Review purchases visible), so we keep both verifiers and
+ *     pick by peeking at the untrusted payload first.
+ *   - Cached verifier instances. Constructing one parses the root certificate;
+ *     serverless invocations are short-lived but often reused.
+ */
+
+import {
+  Environment,
+  SignedDataVerifier,
+  VerificationException,
+  VerificationStatus,
+} from "@apple/app-store-server-library"
+import { appleRootCertificates } from "./apple-root-ca"
+import type {
+  JWSTransactionDecodedPayload,
+  ResponseBodyV2DecodedPayload,
+} from "@apple/app-store-server-library"
+import type { PurchaseAlertConfig } from "./config"
+
+/**
+ * OCSP revocation checks are deliberately off. They add a network round-trip to
+ * Apple on every notification and fail closed when Apple's OCSP responder is
+ * slow, which would turn a transient outage into "Apple retries this in an
+ * hour". Offline chain + validity-window verification is the right trade here:
+ * these notifications only drive a developer alert, never an entitlement — Pro
+ * access is resolved on-device from StoreKit (see ProStore.swift).
+ */
+const ENABLE_ONLINE_CHECKS = false
+
+const verifierCache = new Map<string, SignedDataVerifier>()
+
+function verifierFor(
+  environment: Environment.PRODUCTION | Environment.SANDBOX,
+  config: PurchaseAlertConfig
+): SignedDataVerifier {
+  const key = `${environment}:${config.bundleId}:${config.appAppleId}`
+  const cached = verifierCache.get(key)
+  if (cached) return cached
+
+  const verifier = new SignedDataVerifier(
+    appleRootCertificates(),
+    ENABLE_ONLINE_CHECKS,
+    environment,
+    config.bundleId,
+    // Required for Production, and documented as omitted for Sandbox: sandbox
+    // payloads don't reliably carry an appAppleId to cross-check against.
+    environment === Environment.PRODUCTION ? config.appAppleId : undefined
+  )
+  verifierCache.set(key, verifier)
+  return verifier
+}
+
+/**
+ * Read `data.environment` out of the JWS **without** verifying it, purely to
+ * choose which verifier to try first.
+ *
+ * This value is untrusted by construction — an attacker controls it — but it is
+ * only used to order two verification attempts, both of which validate the
+ * signature and the environment properly. Worst case a forged hint costs one
+ * extra failed verification.
+ */
+function peekEnvironment(signedPayload: string): string | undefined {
+  const segments = signedPayload.split(".")
+  if (segments.length !== 3) return undefined
+  try {
+    const json = Buffer.from(segments[1], "base64url").toString("utf8")
+    const parsed: unknown = JSON.parse(json)
+    if (typeof parsed !== "object" || parsed === null) return undefined
+    const data = (parsed as { data?: unknown }).data
+    if (typeof data !== "object" || data === null) return undefined
+    const environment = (data as { environment?: unknown }).environment
+    return typeof environment === "string" ? environment : undefined
+  } catch {
+    return undefined
+  }
+}
+
+export interface VerifiedNotification {
+  readonly payload: ResponseBodyV2DecodedPayload
+  /**
+   * The decoded transaction, when the notification carries one. Absent for
+   * notification types with no transaction (TEST, RENEWAL_EXTENSION summaries,
+   * external purchase tokens).
+   */
+  readonly transaction: JWSTransactionDecodedPayload | undefined
+  readonly environment: Environment.PRODUCTION | Environment.SANDBOX
+}
+
+/**
+ * Verify a `signedPayload` and decode its nested transaction.
+ *
+ * @throws if neither environment's verifier accepts the payload. The thrown
+ * error is Apple's `VerificationException` for the environment we tried first,
+ * so the status code (INVALID_APP_IDENTIFIER, INVALID_CERTIFICATE, …) survives
+ * into the log.
+ */
+export async function verifyNotification(
+  signedPayload: string,
+  config: PurchaseAlertConfig
+): Promise<VerifiedNotification> {
+  const hint = peekEnvironment(signedPayload)
+  const order: Array<Environment.PRODUCTION | Environment.SANDBOX> =
+    hint === Environment.SANDBOX
+      ? [Environment.SANDBOX, Environment.PRODUCTION]
+      : [Environment.PRODUCTION, Environment.SANDBOX]
+
+  let firstError: unknown
+  for (const environment of order) {
+    try {
+      const verifier = verifierFor(environment, config)
+      const payload = await verifier.verifyAndDecodeNotification(signedPayload)
+      const signedTransactionInfo = payload.data?.signedTransactionInfo
+      const transaction = signedTransactionInfo
+        ? await verifier.verifyAndDecodeTransaction(signedTransactionInfo)
+        : undefined
+      return { payload, transaction, environment }
+    } catch (error) {
+      firstError ??= error
+    }
+  }
+
+  throw firstError instanceof Error
+    ? firstError
+    : new Error("App Store notification failed verification")
+}
+
+/**
+ * A loggable reason for a rejection.
+ *
+ * Apple's `VerificationException` carries an empty `message` and puts the actual
+ * reason in a numeric `status`, so logging `error.message` alone produces a blank
+ * line — useless in exactly the situation you need it (Apple's notifications are
+ * being rejected and you need to know whether it's the bundle id, the app id, the
+ * environment, or the certificate chain).
+ */
+export function describeVerificationFailure(error: unknown): string {
+  if (error instanceof VerificationException) {
+    // TypeScript types the enum's reverse mapping as total, but a status Apple
+    // adds in a later library version would have no entry — so look it up as a
+    // partial record and fall back to the raw number.
+    const statusNames = VerificationStatus as unknown as Record<
+      number,
+      string | undefined
+    >
+    const name = statusNames[error.status] ?? String(error.status)
+    const cause = error.cause?.message
+    return cause
+      ? `VerificationException ${name}: ${cause}`
+      : `VerificationException ${name}`
+  }
+  if (error instanceof Error) {
+    return error.message || error.name
+  }
+  return String(error)
+}

--- a/site/src/routeTree.gen.ts
+++ b/site/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as Char123LocaleChar125FeedbackRouteImport } from './routes/{-$lo
 import { Route as Char123LocaleChar125EngineLevelSpoofingRouteImport } from './routes/{-$locale}.engine-level-spoofing'
 import { Route as Char123LocaleChar125ActivateRouteImport } from './routes/{-$locale}.activate'
 import { Route as Char123LocaleChar125AboutRouteImport } from './routes/{-$locale}.about'
+import { Route as ApiAppleNotificationsRouteImport } from './routes/api.apple-notifications'
 import { Route as Char123LocaleChar125SpoofLocationIndexRouteImport } from './routes/{-$locale}.spoof-location.index'
 import { Route as Char123LocaleChar125BlogIndexRouteImport } from './routes/{-$locale}.blog.index'
 import { Route as Char123LocaleChar125SpoofLocationSafariRouteImport } from './routes/{-$locale}.spoof-location.safari'
@@ -117,6 +118,11 @@ const Char123LocaleChar125AboutRoute =
     path: '/about',
     getParentRoute: () => Char123LocaleChar125Route,
   } as any)
+const ApiAppleNotificationsRoute = ApiAppleNotificationsRouteImport.update({
+  id: '/api/apple-notifications',
+  path: '/api/apple-notifications',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const Char123LocaleChar125SpoofLocationIndexRoute =
   Char123LocaleChar125SpoofLocationIndexRouteImport.update({
     id: '/spoof-location/',
@@ -163,6 +169,7 @@ const Char123LocaleChar125BlogSlugRoute =
 export interface FileRoutesByFullPath {
   '/test': typeof TestRoute
   '/{-$locale}': typeof Char123LocaleChar125RouteWithChildren
+  '/api/apple-notifications': typeof ApiAppleNotificationsRoute
   '/{-$locale}/about': typeof Char123LocaleChar125AboutRoute
   '/{-$locale}/activate': typeof Char123LocaleChar125ActivateRoute
   '/{-$locale}/engine-level-spoofing': typeof Char123LocaleChar125EngineLevelSpoofingRoute
@@ -186,6 +193,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/test': typeof TestRoute
+  '/api/apple-notifications': typeof ApiAppleNotificationsRoute
   '/{-$locale}/about': typeof Char123LocaleChar125AboutRoute
   '/{-$locale}/activate': typeof Char123LocaleChar125ActivateRoute
   '/{-$locale}/engine-level-spoofing': typeof Char123LocaleChar125EngineLevelSpoofingRoute
@@ -211,6 +219,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/test': typeof TestRoute
   '/{-$locale}': typeof Char123LocaleChar125RouteWithChildren
+  '/api/apple-notifications': typeof ApiAppleNotificationsRoute
   '/{-$locale}/about': typeof Char123LocaleChar125AboutRoute
   '/{-$locale}/activate': typeof Char123LocaleChar125ActivateRoute
   '/{-$locale}/engine-level-spoofing': typeof Char123LocaleChar125EngineLevelSpoofingRoute
@@ -237,6 +246,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/test'
     | '/{-$locale}'
+    | '/api/apple-notifications'
     | '/{-$locale}/about'
     | '/{-$locale}/activate'
     | '/{-$locale}/engine-level-spoofing'
@@ -260,6 +270,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/test'
+    | '/api/apple-notifications'
     | '/{-$locale}/about'
     | '/{-$locale}/activate'
     | '/{-$locale}/engine-level-spoofing'
@@ -284,6 +295,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/test'
     | '/{-$locale}'
+    | '/api/apple-notifications'
     | '/{-$locale}/about'
     | '/{-$locale}/activate'
     | '/{-$locale}/engine-level-spoofing'
@@ -309,6 +321,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   TestRoute: typeof TestRoute
   Char123LocaleChar125Route: typeof Char123LocaleChar125RouteWithChildren
+  ApiAppleNotificationsRoute: typeof ApiAppleNotificationsRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -417,6 +430,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/{-$locale}/about'
       preLoaderRoute: typeof Char123LocaleChar125AboutRouteImport
       parentRoute: typeof Char123LocaleChar125Route
+    }
+    '/api/apple-notifications': {
+      id: '/api/apple-notifications'
+      path: '/api/apple-notifications'
+      fullPath: '/api/apple-notifications'
+      preLoaderRoute: typeof ApiAppleNotificationsRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/{-$locale}/spoof-location/': {
       id: '/{-$locale}/spoof-location/'
@@ -529,6 +549,7 @@ const Char123LocaleChar125RouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   TestRoute: TestRoute,
   Char123LocaleChar125Route: Char123LocaleChar125RouteWithChildren,
+  ApiAppleNotificationsRoute: ApiAppleNotificationsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/site/src/routes/api.apple-notifications.ts
+++ b/site/src/routes/api.apple-notifications.ts
@@ -1,0 +1,82 @@
+/**
+ * POST /api/apple-notifications — App Store Server Notifications V2 receiver.
+ *
+ * This is the endpoint registered in App Store Connect (App Information ▸ App
+ * Store Server Notifications) for BOTH the Production and Sandbox URLs. Apple
+ * POSTs a signed JWS whenever a purchase, renewal, refund or cancellation
+ * happens; we verify it, decide whether it's worth reporting, and forward a
+ * one-liner to a chat webhook.
+ *
+ * It is intentionally *only* an alerting path. Pro entitlement is resolved
+ * on-device from StoreKit 2 (`ProStore.swift`) and the GPS agent verifies the
+ * Apple-signed JWS offline — nothing here grants, revokes, or stores access, so
+ * an outage of this route costs a notification and nothing else.
+ *
+ * Security model, since this URL is necessarily public and unauthenticated in
+ * the usual sense (Apple sends no bearer token and publishes no source IPs):
+ *   - `APPLE_NOTIFICATIONS_TOKEN`, when set, must appear as `?token=…`. This is
+ *     checked before the body is read, before any crypto, and before the
+ *     verification module is even loaded, so unauthenticated traffic is as close
+ *     to free as an invocation gets. A miss answers 404, not 403, so the endpoint
+ *     doesn't confirm itself to a scanner.
+ *   - The JWS signature is the real authentication: chain must terminate at the
+ *     embedded Apple Root CA - G3, and the payload's bundle id / appAppleId must
+ *     match this app. See `lib/purchase-alerts/verify.ts`.
+ *
+ * Status codes matter here, because a non-2xx makes Apple retry (roughly 1h,
+ * 12h, 24h, 48h, 72h):
+ *   200  handled, ignored by design, or a duplicate — nothing to retry
+ *   400  body wasn't `{ "signedPayload": "…" }`
+ *   401  signature/app-identity verification failed — retrying won't help, but a
+ *        forged request retrying harmlessly is preferable to acking it
+ *   404  URL token missing or wrong
+ *   500  verified fine, but the chat webhook was unreachable — DO retry
+ *
+ * Runtime note: this must stay on the Node runtime. Verification uses
+ * `node:crypto`'s X509Certificate and Buffer, neither of which exists on the
+ * Edge runtime.
+ */
+
+import { timingSafeEqual } from "node:crypto"
+import { createFileRoute } from "@tanstack/react-router"
+import { readConfig } from "@/lib/purchase-alerts/config"
+
+function tokenMatches(expected: string, provided: string | null): boolean {
+  if (provided === null) return false
+  const a = Buffer.from(expected, "utf8")
+  const b = Buffer.from(provided, "utf8")
+  // timingSafeEqual throws on length mismatch; length is not the secret here.
+  return a.length === b.length && timingSafeEqual(a, b)
+}
+
+export const Route = createFileRoute("/api/apple-notifications")({
+  server: {
+    handlers: {
+      // Without this, a GET falls through to the SPA shell and answers 200 with
+      // an empty page — which is both misleading and indexable.
+      GET: () =>
+        new Response("Method not allowed", {
+          status: 405,
+          headers: { Allow: "POST" },
+        }),
+
+      POST: async ({ request }) => {
+        const { urlToken } = readConfig()
+
+        if (urlToken) {
+          const provided = new URL(request.url).searchParams.get("token")
+          if (!tokenMatches(urlToken, provided)) {
+            return new Response("Not found", { status: 404 })
+          }
+        }
+
+        // Loaded on demand: this pulls in Apple's verification library, which
+        // would otherwise be initialised on every server-rendered request in
+        // the shared SSR bundle. See the header of `handle.ts`.
+        const { handleNotification } =
+          await import("@/lib/purchase-alerts/handle")
+        return handleNotification(request)
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Adds `POST /api/apple-notifications` to the site, which receives App Store Server Notifications V2 and posts purchases, trials, renewals, refunds and cancellations to a private Discord channel.

Alerting only. Pro entitlement stays resolved on-device by StoreKit (`ProStore.swift`) and the GPS agent still verifies the Apple-signed JWS offline — nothing here grants, revokes or stores access, so an outage of this route costs a notification and nothing else.

It lives on the site because `site/` already has a server runtime on Vercel, while the CDK stack is a static CDN only (no Lambda, and its CloudFront behavior allows GET/HEAD/OPTIONS). If transaction storage or server-side entitlement is ever needed, the three lib modules are framework-free and port to Lambda with only the `Request`/`Response` wrapper changing.

## Behaviour worth reviewing

- **Verification is the authentication.** Apple sends no bearer token and publishes no source IPs, so the endpoint validates the JWS chain against an embedded Apple Root CA - G3 and cross-checks bundle id + `appAppleId`. An optional `?token=` shared secret is checked before the body is read, before any crypto, and before the verification module is loaded, so unauthenticated traffic is as cheap as an invocation gets and answers 404 rather than confirming the endpoint exists.
- **Trials are not sales.** Both Pro plans carry a free introductory offer, so `SUBSCRIBED/INITIAL_BUY` fires at trial start with `price: 0`. Those are labelled `TRIAL` with the conversion date; revenue shows up on the first `DID_RENEW`.
- **Family Sharing is not a sale.** Same notification type, no charge, labelled separately.
- **Sandbox is tagged**, so TestFlight and App Review purchases can't be mistaken for revenue.
- **Status codes are load-bearing**, because any non-2xx makes Apple redeliver for roughly three days. 200 for handled/ignored/duplicate, 401 for a bad signature, and 500 *only* when the webhook itself was unreachable so a chat outage doesn't lose a sale. A `notificationUUID` is recorded as delivered only after delivery succeeds, so those retries can still land.
- **Discord posts can't ping a server.** `allowed_mentions` disables `@everyone`/`@here`/roles; only the configured user id may be mentioned. The mention exists because a webhook post pings nobody and servers default to "Only @mentions", which would mean alerts never reach a phone.
- **The Apple library loads lazily.** A static import put it in the shared SSR router chunk, so every server-rendered request initialised a certificate verifier it would never use. Behind `await import(...)` it's a separate chunk, confirmed in the build output.
- Notification types that are pure plumbing (consumption requests, price-increase notices, renewal-date extensions) and anything unrecognised are deliberately silent.

## Config

`PURCHASE_ALERT_WEBHOOK_URL`, `APPLE_NOTIFICATIONS_TOKEN`, `PURCHASE_ALERT_DISCORD_MENTION` — set in Vercel, Production scope only. Apple's bundle id and app id default to GeoSpoof's real public values. Documented in `site/README.md`.

## Testing

- 43 unit tests pass (20 formatting/filtering, 12 delivery, plus the existing suite). Fixture-driven, no credentials or network.
- `lint`, `tsc --noEmit`, and a production build all clean; 216 pages prerendered.
- Client bundle and all prerendered HTML confirmed free of the endpoint path, both env var names, the verification library, and the embedded certificate.
- Runtime matrix against the built Nitro server: `GET` 405, POST without token 404, wrong token 404, bad body 400, forged JWS 401, unrelated pages still 200.

## Not yet verified

A real Apple-signed notification reaching Discord — that can't be forged locally. After deploy, either `node scripts/apple-test-notification.mjs` (needs an In-App Purchase key from Users and Access ▸ Integrations, Admin role — not the fastlane `ASC_API_KEY_P8`, which is a different key type) or a sandbox purchase in TestFlight.

## Follow-up, unrelated

`npm run build` in `site/` needs `NODE_EXTRA_CA_CERTS="$(mkcert -CAROOT)/rootCA.pem"` locally: `site/certs/` makes the prerender server HTTPS and Node doesn't trust the mkcert root, so prerendering silently produces 0 pages while still exiting 0. Pre-existing, not from this change.